### PR TITLE
Fix terminal startup rendering with Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repository is an Electron Forge + Vite + TypeScript (v5.9.3) desktop app wi
 ## Run Commands
 
 - Start in development: `npm start`
+- Start in development and explicitly open docked DevTools: `KALE_OPEN_DEVTOOLS=1 npm start`
 - Start in development with a custom window size: `KALE_WINDOW_WIDTH=1800 KALE_WINDOW_HEIGHT=1100 npm start`
 - Capture a screenshot of an already-running `kale` Electron window into `/tmp` as a JPG: `scripts/capture_npm_start_window.sh` (optional args: capture delay seconds, output path). The script prints the generated file path.
 - Run unit tests: `npm test`
@@ -80,7 +81,7 @@ The E2E test (`tests/e2e/happy-path.js`) launches the full Electron app via Play
 - `src/renderer/InlineCommentCard.tsx`: individual comment card UI (textarea auto-size, delete action, autofocus, resize reporting for layout).
 - `src/renderer/line-merge.ts`: pure line-level three-way merge function for reconciling concurrent user and external (Claude) edits to the same document. Uses `node-diff3`; conflicts resolve in favor of the disk version.
 - `src/renderer/inline-comments.ts`: parser/helpers for hidden HTML comment markers used as the canonical inline-comment source of truth.
-- `src/renderer/TerminalPane.tsx`: reusable embedded PTY terminal pane component used by the main app, including preset prompt buttons that inject common Claude requests into the active terminal session and submit them automatically.
+- `src/renderer/TerminalPane.tsx`: reusable embedded PTY terminal pane component used by the main app, including xterm fit/resize synchronization for PTY geometry and preset prompt buttons that inject common Claude requests into the active terminal session and submit them automatically.
 - `docs/`: product and architecture documentation (requirements, decisions, planning notes).
 - `docs/todos.md`: tracked known issues and deferred fixes.
 - `mockups/`: static UI mockups/prototypes used to explore interaction and visual direction.
@@ -98,7 +99,7 @@ The Electron main process is now organized as a thin orchestrator plus domain se
 - `src/main.ts` wires Electron lifecycle events (`ready`, `activate`, `window-all-closed`) to service startup/shutdown and IPC registration.
 - `src/main/window.ts` owns BrowserWindow creation and Forge/Vite renderer/preload entry loading.
 - `src/main/markdown-file-service.ts` owns active markdown file state, settings persistence, file open/load/save/restore IPC handlers, and chokidar-based file watching/broadcasts.
-- `src/main/terminal-session-service.ts` owns PTY session state, Claude CLI startup validation/prompt-template preload, and terminal IPC handlers.
+- `src/main/terminal-session-service.ts` owns PTY session state, Claude CLI startup validation/prompt-template preload, terminal IPC handlers, and renderer-provided initial PTY geometry for correct first-frame full-screen CLI rendering.
 - `src/main/ide-integration-service.ts` owns IDE MCP server lifecycle, cached editor selection state, and the `ide:selection-changed` IPC handler/debounced Claude notifications.
 
 Cross-service coordination stays explicit through small APIs/callbacks (for example, terminal and IDE services read the active file path from the markdown file service) rather than through a single shared runtime-state object.

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -4,6 +4,16 @@ import path from 'node:path';
 const DEFAULT_WINDOW_WIDTH = 2560;
 const DEFAULT_WINDOW_HEIGHT = 1440;
 
+// Development visibility of DevTools is env-controlled so layout-sensitive UI
+// bugs can be reproduced without the extra docked DevTools relayout.
+const shouldOpenDevTools = (isHeadless: boolean) => {
+  if (isHeadless) {
+    return false;
+  }
+
+  return process.env.KALE_OPEN_DEVTOOLS === '1';
+};
+
 // Window sizing is environment-configurable in development so contributors can
 // quickly test layouts without changing checked-in defaults.
 const parseWindowDimension = (value: string | undefined, fallback: number) => {
@@ -44,9 +54,9 @@ export const createMainWindow = () => {
     );
   }
 
-  // DevTools are kept open in this prototype to speed iteration while main
-  // process and renderer integration are still changing frequently.
-  if (!isHeadless) {
+  // DevTools are opt-in because a docked DevTools window can trigger extra
+  // startup relayouts that hide timing bugs in layout-sensitive components.
+  if (shouldOpenDevTools(isHeadless)) {
     mainWindow.webContents.openDevTools();
   }
 

--- a/src/shared-types.ts
+++ b/src/shared-types.ts
@@ -30,6 +30,8 @@ export type RestoreMarkdownFromGitResponse =
 export type StartTerminalSessionRequest = {
   cwd: string;
   targetFilePath: string;
+  initialCols?: number;
+  initialRows?: number;
 };
 
 export type StartTerminalSessionResponse =


### PR DESCRIPTION
## Summary
- start the PTY with renderer-measured initial xterm geometry so Claude boots at the correct size
- stop writing Kale startup/reset status lines into the embedded terminal before Claude renders
- make DevTools opt-in () so layout-sensitive startup behavior can be reproduced reliably
- update README docs for the terminal pane/main service notes and the DevTools run command

## Validation
- 
> kale@1.0.0 format
> prettier --write . --ignore-unknown

.eslintrc.json 15ms (unchanged)
.github/workflows/ci.yml 16ms (unchanged)
.prettierrc.json 1ms (unchanged)
forge.config.ts 27ms (unchanged)
forge.env.d.ts 2ms (unchanged)
index.html 13ms (unchanged)
package.json 1ms (unchanged)
src/ide-server/index.ts 1ms (unchanged)
src/ide-server/lock-file.ts 7ms (unchanged)
src/ide-server/mcp-handlers.ts 14ms (unchanged)
src/ide-server/types.ts 4ms (unchanged)
src/ide-server/websocket-server.ts 11ms (unchanged)
src/index.css 33ms (unchanged)
src/main.ts 4ms (unchanged)
src/main/ide-integration-service.ts 6ms (unchanged)
src/main/markdown-file-service.ts 17ms (unchanged)
src/main/terminal-session-service.ts 13ms (unchanged)
src/main/window.ts 3ms (unchanged)
src/preload.ts 5ms (unchanged)
src/renderer/App.tsx 18ms (unchanged)
src/renderer/codemirror-extensions.ts 18ms (unchanged)
src/renderer/DocumentCommentsPane.tsx 10ms (unchanged)
src/renderer/ide-server-api.ts 2ms (unchanged)
src/renderer/inline-comments.ts 9ms (unchanged)
src/renderer/InlineCommentCard.tsx 4ms (unchanged)
src/renderer/InlineCommentsSidebar.tsx 3ms (unchanged)
src/renderer/line-merge.test.ts 19ms (unchanged)
src/renderer/line-merge.ts 2ms (unchanged)
src/renderer/main.tsx 1ms (unchanged)
src/renderer/markdown-api.ts 1ms (unchanged)
src/renderer/MarkdownEditorPane.tsx 13ms (unchanged)
src/renderer/save-controller.ts 2ms (unchanged)
src/renderer/terminal-api.ts 1ms (unchanged)
src/renderer/TerminalPane.tsx 12ms (unchanged)
src/renderer/use-latest-ref.ts 1ms (unchanged)
src/shared-types.ts 2ms (unchanged)
src/types/node-diff3.d.ts 1ms (unchanged)
tests/e2e/happy-path.js 10ms (unchanged)
tsconfig.json 1ms (unchanged)
vite.main.config.ts 1ms (unchanged)
vite.preload.config.ts 0ms (unchanged)
vite.renderer.config.ts 1ms (unchanged)
vitest.config.ts 0ms (unchanged)
- 
> kale@1.0.0 lint
> eslint --ext .ts,.tsx .
- manually reproduced with 
> kale@1.0.0 start
> electron-forge start

❯ Checking your system
❯ Checking package manager version
✔ Found npm@10.9.4
✔ Checking your system
[?25h❯ Locating application
✔ Locating application
❯ Loading configuration
✔ Loading configuration
❯ Preparing native dependencies
✔ Preparing native dependencies: 1 / 1
❯ Running generateAssets hook
✔ Running generateAssets hook
❯ Running preStart hook
❯ [plugin-vite] Preparing Vite bundles
❯ Launching Vite dev servers for renderer process code...
❯ Target main_window
Port 5173 is in use, trying another one...
›   ➜  Local:   http://localhost:5174/  
› ➜  Network: use --host to expose
✔ Target main_window
✔ Launched Vite dev servers for renderer process code
❯ Building main process and preload bundles...
❯ Building src/main.ts target
❯ Building src/preload.ts target
3:59:58 PM [@electron-forge/plugin-vite] target built src/preload.ts
✔ Building src/preload.ts target
3:59:58 PM [@electron-forge/plugin-vite] target built src/main.ts
✔ Building src/main.ts target
✔ Built main process and preload bundles
✔ [plugin-vite] Preparing Vite bundles
✔ Running preStart hook
✔ Launched Electron app. Type rs in terminal to restart main process.
[?25h (no DevTools) and verified the terminal starts directly in the Claude UI without stale text above it

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix terminal startup rendering by adjusting PTY geometry and making DevTools optional, with updates to README and terminal session management.
> 
>   - **Behavior**:
>     - Start PTY with renderer-measured initial xterm geometry in `terminal-session-service.ts` to ensure correct terminal size on startup.
>     - Stop writing Kale startup/reset status lines into the terminal before Claude renders in `TerminalPane.tsx`.
>     - Make DevTools opt-in in `window.ts` to reproduce layout-sensitive startup behavior reliably.
>   - **Documentation**:
>     - Update README to include notes on terminal pane/main service and DevTools run command.
>   - **Functions**:
>     - Add `resolveInitialPtyGeometryForSpawn()` in `terminal-session-service.ts` to calculate initial PTY geometry.
>     - Add `measureStableTerminalGeometryBeforeSessionStart()` in `TerminalPane.tsx` to ensure stable terminal geometry before session start.
>   - **Misc**:
>     - Minor refactoring and cleanup in `TerminalPane.tsx` to improve terminal rendering and session management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=akurilin%2Fkale&utm_source=github&utm_medium=referral)<sup> for a9c58c33299cc9c78832415eb940872b99199e83. You can [customize](https://app.ellipsis.dev/akurilin/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->