### PR TITLE
Fix shellcheck false-positive for trap cleanup

### DIFF
--- a/scripts/start-with-cdp.sh
+++ b/scripts/start-with-cdp.sh
@@ -166,7 +166,7 @@ fi
 
 # Why: session terminals are the lifecycle boundary in agentic QA, so cleanup
 # on signal/exit must terminate only this script's Electron child process.
-# shellcheck disable=SC2329 # Invoked via trap below, not by direct call.
+# shellcheck disable=SC2317,SC2329 # Invoked via trap below; ShellCheck 0.9 misclassifies trap-only functions as unreachable.
 cleanup() {
   local script_exit_code=$?
   trap - EXIT INT TERM HUP


### PR DESCRIPTION
## Summary\n- fix CI failure caused by ShellCheck 0.9 reporting SC2317 on trap-only cleanup function\n- keep runtime behavior unchanged by extending the existing shellcheck suppression to include SC2317\n\n## Validation\n- npm run validate:static\n- GitHub Actions CI run: https://github.com/akurilin/kale/actions/runs/22834963038